### PR TITLE
BUG: Fix use of deprecated unencrypted git protocol

### DIFF
--- a/FetchIMSTK.cmake
+++ b/FetchIMSTK.cmake
@@ -5,7 +5,7 @@ set(proj iMSTK)
 set(EP_SOURCE_DIR "${CMAKE_BINARY_DIR}/${proj}")
 FetchContent_Populate(${proj}
   SOURCE_DIR     ${EP_SOURCE_DIR}
-  GIT_REPOSITORY git://github.com/KitwareMedical/iMSTK.git
+  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/KitwareMedical/iMSTK.git
   GIT_TAG        6997eab385ca2eac6c1f192663cde809810f220a  # slicerimstk-v5.0.0-2021-12-18-c55b3ed11
   QUIET
   )

--- a/FetchVTKExternalModule.cmake
+++ b/FetchVTKExternalModule.cmake
@@ -5,7 +5,7 @@ set(proj VTKExternalModule)
 set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
 FetchContent_Populate(${proj}
   SOURCE_DIR     ${EP_SOURCE_DIR}
-  GIT_REPOSITORY git://github.com/KitwareMedical/VTKExternalModule
+  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/KitwareMedical/VTKExternalModule
   GIT_TAG        39cad030130437f58028b0b6b7735c51d44704ff
   QUIET
   )


### PR DESCRIPTION
On March 15, 2022 git stopped accepting clones via the unencrypted git
protocol.
This commit changes to use https:// instead of git://
https://github.blog/2021-09-01-improving-git-protocol-security-github/