### PR TITLE
ENH: Update VTKExternalModule

### DIFF
--- a/FetchVTKExternalModule.cmake
+++ b/FetchVTKExternalModule.cmake
@@ -6,7 +6,7 @@ set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
 FetchContent_Populate(${proj}
   SOURCE_DIR     ${EP_SOURCE_DIR}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/KitwareMedical/VTKExternalModule
-  GIT_TAG        39cad030130437f58028b0b6b7735c51d44704ff
+  GIT_TAG        363224e0f9500ecd0b3c4627444e254b346e5994
   QUIET
   )
 message(STATUS "Remote - ${proj} [OK]")


### PR DESCRIPTION
List of changes:

```
$ git shortlog 39cad0301..363224e0f --no-merges
Jean-Christophe Fillion-Robin (2):
      Add support for externally building a VTK modules and its dependencies
      Add support for externally building tests of a VTK modules
```