### PR TITLE
COMP: Fix enabling of OpenHaptics setting macro based on iMSTK_USE_OpenHaptics

### DIFF
--- a/IMSTK/Logic/CMakeLists.txt
+++ b/IMSTK/Logic/CMakeLists.txt
@@ -34,6 +34,7 @@ set(${KIT}_TARGET_LIBRARIES
   ${iMSTK_LIBRARIES}
   )
 
+set(Slicer_iMSTK_USE_OpenHaptics ${iMSTK_USE_OpenHaptics})
 set(configure_header_file vtkSlicerIMSTKLogicConfigure.h)
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/${configure_header_file}.in


### PR DESCRIPTION
This commit is a follow-up of 00b54cd (COMP: Enable OpenHaptics support
only on Windows) to ensure the macro `Slicer_iMSTK_USE_OpenHaptics` is
effectively defined if iMSTK is built with OpenHaptics support.